### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Very simple PUCT to experiment with leela networks in Python.
 
 - setup a python virtual environment with python3
 - clone the mcts branch of https://github.com/dkappe/lczero_tools/tree/mcts
-- install so you can edit `pip -e install .`
+- install so you can edit `pip install -e.`
 - run leela_lite with weights file and number of nodes: `python leela_lite.py weights_9149.txt.gz 200` (for example)
 
 ## What it needs


### PR DESCRIPTION
Build instructions now suggest `pip install -e` which works rather than `pip -e install ` which doesn't