### PR TITLE
Only copy board if it's actually going to be evaluated

### DIFF
--- a/uct/uct.py
+++ b/uct/uct.py
@@ -81,9 +81,9 @@ def UCT_search(board, num_reads, net=None, C=1.0):
         leaf.expand(child_priors)
         leaf.backup(value_estimate)
 
-    for m, node in sorted(root.children.items(),
-                          key=lambda item: (item[1].number_visits, item[1].Q())):
-        node.dump(m, C)
+    #for m, node in sorted(root.children.items(),
+    #                      key=lambda item: (item[1].number_visits, item[1].Q())):
+    #    node.dump(m, C)
     return max(root.children.items(),
                key=lambda item: (item[1].number_visits, item[1].Q()))
 


### PR DESCRIPTION
Currently all children boards are created and moves pushed. However, this is taking a lot of time. Eliminating that overhead results in something like a 40% reduction of time... With this optimization, NN evals take about 90% of the time, and board manipulation takes most of the rest of the time.

Also, modified Q to be more consistent with lc0. However, returning 0 if no visits does not match lc0. This should be revisited.